### PR TITLE
Use a tokenizer for tuple reading, handle tuples from tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: test
 test: test-tuple test-utils
 
+.PHONY: test-tokenizer
+test-tokenizer:
+	swipl -g run_tests -t halt zanzibar_tokenizer_test.pl
+
 .PHONY: test-tuple
 test-tuple:
 	swipl -g run_tests -t halt zanzibar_tuple_test.pl

--- a/zanzibar_tokenizer.pl
+++ b/zanzibar_tokenizer.pl
@@ -1,0 +1,151 @@
+:- module(zanzibar_tokenizer,
+    [tokenize/2]).
+
+:- set_prolog_flag(double_quotes, chars).
+:- use_module(library(dcg/basics)).
+:- use_module(library(lists)).
+:- use_module(zanzibar_utils).
+
+% -------------------------------------------|
+% Whitespace, including new line:
+% -------------------------------------------|
+
+spaces      --> space, !, spaces.
+spaces      --> [].
+space       -->
+    [C],
+    (
+        { code_type(C, space) }, !
+        | { code_type(C, white) }, !
+    ).
+
+% -------------------------------------------|
+% Quoted strings definition:
+% -------------------------------------------|
+
+double_quote --> "\"".
+single_quote --> "'".
+
+quoted(Out) --> double_quoted(Out), !.
+quoted(Out) --> single_quoted(Out), !.
+
+double_quoted(Out) --> quoted_terminated(double_quote, '\"', Out), !.
+single_quoted(Out) --> quoted_terminated(single_quote, '\'', Out), !.
+quoted_terminated(Terminator, TerminatorChar, Out) -->
+    Terminator,
+    quoted_chars(TerminatorChar, Content),
+    { lists:flatten(Content, Out) },
+    Terminator.
+
+quoted_chars(TC, [H|T]) --> next_quoted_char(H), { TC \= H }, quoted_chars(TC, T).
+quoted_chars(_, [])     --> [].
+
+next_quoted_char(['\\', C]) --> ['\\', C], !.
+next_quoted_char(E)         --> ['\r','\n'], { E = error(quoted_multiline) }.
+next_quoted_char(E)         --> ['\n'],      { E = error(quoted_multiline) }.
+next_quoted_char(E)         --> ['\r'],      { E = error(quoted_multiline) }.
+next_quoted_char(H)         --> [H], !.
+
+% -------------------------------------------|
+% Keyword and tokens definition:
+% -------------------------------------------|
+
+keyword([H|T]) --> [H], { char_type(H, alnum) }, !, keyword(T).
+keyword([])    --> [].
+
+tokens([H|T]) --> spaces, token(H), !,
+    (
+        { zanzibar_utils:is_error(H) }, ! % Abort reading tokens as soon as there's an error.
+        | spaces, tokens(T), !            % Otherwise, continue reading tokens.
+    ).
+tokens([]) --> [].
+
+% -------------------------------------------|
+% Read numbers:
+% -------------------------------------------|
+% Documentation says that the number//1 predicate handles floats but it doesn't look like it.
+% Code suggests so: https://github.com/SWI-Prolog/swipl-devel/blob/96d60f7327a53e2fe3ec3c0ceff49ed7af4c1fd4/library/dcg/basics.pl#L304-L333.
+% But...:
+%   phrase(number(X), "123.4") gives false.
+% Surprisingly:
+%   phrase(float(X), "123.4") also gives false.
+% Whatever, let's do this ourselves.
+
+token(token(float, Out)) --> number(N1), ['.'], number(N2), !,
+    { lists:flatten([N1, ['.'], N2], Out) }.
+token(token(float, Out)) --> ['.'], number(N1), !,
+    { lists:flatten([['0','.'], N1], Out) }.
+token(token(float, Out)) --> number(N1), ['.'], !,
+    { lists:flatten([N1, ['.','0']], Out) }.
+token(token(number, N)) --> number(N).
+
+% -------------------------------------------|
+% Read symbols:
+% -------------------------------------------|
+% After numbers because we have the special treating of .\d+ as a float.
+
+token(token(symbol, '...')) --> ['.','.','.'], !.
+token(token(symbol, '<=')) --> ['<','='], !.
+token(token(symbol, '>=')) --> ['>','='], !.
+token(token(symbol, '==')) --> ['=','='], !.
+token(token(symbol, '!=')) --> ['!','='], !.
+
+token(token(scope_s, '{')) --> ['{'], !.
+token(token(scope_e, '}')) --> ['}'], !.
+token(token(array_s, '[')) --> ['['], !.
+token(token(array_e, ']')) --> [']'], !.
+token(token(symbol, '.')) --> ['.'], !.
+token(token(symbol, '(')) --> ['('], !.
+token(token(symbol, ')')) --> [')'], !.
+token(token(symbol, '>')) --> ['>'], !.
+token(token(symbol, '/')) --> ['/'], !.
+token(token(symbol, '|')) --> ['|'], !.
+token(token(symbol, '<')) --> ['<'], !.
+token(token(symbol, '~')) --> ['~'], !.
+token(token(symbol, '`')) --> ['`'], !.
+token(token(symbol, '!')) --> ['!'], !.
+token(token(symbol, '@')) --> ['@'], !.
+token(token(symbol, '#')) --> ['#'], !.
+token(token(symbol, '$')) --> ['$'], !.
+token(token(symbol, '%')) --> ['%'], !.
+token(token(symbol, '^')) --> ['^'], !.
+token(token(symbol, '&')) --> ['&'], !.
+token(token(symbol, '*')) --> ['*'], !.
+token(token(symbol, '_')) --> ['_'], !.
+token(token(symbol, '-')) --> ['-'], !.
+token(token(symbol, '+')) --> ['+'], !.
+token(token(symbol, ',')) --> [','], !.
+token(token(symbol, ':')) --> [':'], !.
+token(token(assign, '=')) --> ['='], !.
+
+% -------------------------------------------|
+% Read quoted strings:
+% -------------------------------------------|
+% Quoted strings: first, try reading as a quoted string.
+% On backtracking, if we have a quote, it's an unterminated quoted string.
+% BUT, let's accept any escaped dangling quote.
+
+token(token(qs, Kw)) --> {Kw = [_|_]}, quoted(Kw), !.
+token(token(symbol, C)) --> ['\\', C], !.
+token(error(unterminated, '\"', R)) --> ['\"'], remainder(R), !.
+token(error(unterminated, '\'', R)) --> ['\''], remainder(R), !.
+
+% -------------------------------------------|
+% Read keywords:
+% -------------------------------------------|
+
+token(token(kw, Kw)) --> {Kw = [_|_]}, keyword(Kw), !.
+
+% -------------------------------------------|
+% Catch-all unknown input:
+% -------------------------------------------|
+
+token(error(unknown, C, R)) --> [C], remainder(R), !.
+
+% -------------------------------------------|
+% API:
+% -------------------------------------------|
+
+tokenize(Input, tokens(Out)) :-
+    Phrase =.. [tokens, Out],
+    phrase(Phrase, Input).

--- a/zanzibar_tokenizer_test.pl
+++ b/zanzibar_tokenizer_test.pl
@@ -1,0 +1,64 @@
+:- begin_tests(zanzibar_tokenizer_tests).
+
+% Enable double-quoted strings for ease of use.
+:- set_prolog_flag(double_quotes, chars).
+:- use_module(zanzibar_tokenizer).
+
+test(valid_keywords, [ true(
+    Out=tokens([token(kw, "kw1"), token(kw, "kw2")])
+    )]) :- zanzibar_tokenizer:tokenize("kw1 kw2", Out).
+
+test(valid_floats, [ true(
+    Out=tokens([token(float, [1234, '.', 56]), token(float, ['0', '.', 123]), token(float, [987, '.', '0'])])
+    )]) :- zanzibar_tokenizer:tokenize("1234.56 .123 987.", Out).
+
+test(valid_int, [ true(
+    Out=tokens([token(number, 42), token(number, 2022)])
+    )]) :- zanzibar_tokenizer:tokenize("   42    2022   ", Out).
+
+test(valid_tokens, [ true(
+    Out=tokens([
+        token(kw, "name"),
+        token(assign, '='),
+        token(qs, "value"),
+        token(kw, "relation"),
+        token(scope_s, '{'),
+        token(symbol, '+'),
+        token(symbol, '-'),
+        token(symbol, '\\'),
+        token(symbol, '\"'),
+        token(symbol, '\''),
+        token(symbol, '=='),
+        token(symbol, '!='),
+        token(symbol, '...'),
+        token(symbol, '.'),
+        token(kw, "nested"),
+        token(array_s, '['),
+        token(array_e, ']'),
+        token(qs, "single quoted"),
+        token(scope_e, '}')])
+    )]) :- zanzibar_tokenizer:tokenize("name = \"value\" relation { +- \\\\ \\\" \\' == != ... . nested [] 'single quoted' }", Out).
+
+test(handles_unterminated_double_quoted, [ true(
+    Out=tokens([
+        token(kw, "name"),
+        token(assign, '='),
+        token(qs, "value"),
+        token(kw, "relation"),
+        token(scope_s, '{'),
+        error(unterminated, '\"', "unterminated follows")
+        | _])
+    )]) :- zanzibar_tokenizer:tokenize("name = \"value\" relation { \"unterminated follows", Out).
+
+test(handles_unterminated_single_quoted, [ true(
+    Out=tokens([
+        token(kw, "name"),
+        token(assign, '='),
+        token(qs, "value"),
+        token(kw, "relation"),
+        token(scope_s, '{'),
+        error(unterminated, '\'', "unterminated follows")
+        | _])
+    )]) :- zanzibar_tokenizer:tokenize("name = \"value\" relation { 'unterminated follows", Out).
+
+:- end_tests(zanzibar_tokenizer_tests).

--- a/zanzibar_tuple_test.pl
+++ b/zanzibar_tuple_test.pl
@@ -1,42 +1,108 @@
 :- begin_tests(zanzibar_tuple_tests).
+
 % Enable double-quoted strings for ease of use.
 :- set_prolog_flag(double_quotes, chars).
 :- use_module(zanzibar_tuple).
 
-test(valid_no_userset) :-
-    zanzibar_tuple:parse_tuple("ns:object#rel", Out),
-    Out = t(o("ns", "object"), r("rel"), u(none)).
+test(valid_no_userset, [ true(
+    Out=t(
+        o("ns", "object"),
+        r("rel"),
+        u(none)
+    ))]) :- zanzibar_tuple:parse_tuple("ns:object#rel", Out).
 
-test(valid_userset) :-
-    zanzibar_tuple:parse_tuple("ns:object#rel@set:object#rel", Out),
-    Out = t(o("ns", "object"), r("rel"), u(set(o("set", "object"), r("rel")))).
+test(valid_userset, [ true(
+        Out=t(
+            o("ns", "object"),
+            r("rel"),
+            u(set(o("set", "object"), r("rel")))
+    ))]) :- zanzibar_tuple:parse_tuple("ns:object#rel@set:object#rel", Out).
 
-test(valid_userset_dotdotdot_relation) :-
-    zanzibar_tuple:parse_tuple("ns:object#rel@set:object#...", Out),
-    Out = t(o("ns", "object"), r("rel"), u(set(o("set", "object"), r("...")))).
+test(valid_userset_dotdotdot_relation, [ true(
+    Out=t(
+        o("ns", "object"), 
+        r("rel"), 
+        u(set(o("set", "object"), r("...")))
+    ))]) :- zanzibar_tuple:parse_tuple("ns:object#rel@set:object#...", Out).
 
-test(valid_userid) :-
-    zanzibar_tuple:parse_tuple("ns:object#rel@user-id", Out),
-    Out = t(o("ns", "object"), r("rel"), u(id("user-id"))).
+test(valid_userid, [ true(
+    Out=t(
+        o("ns", "object"), 
+        r("rel"), 
+        u(id("userid"))
+    ))]) :- zanzibar_tuple:parse_tuple("ns:object#rel@userid", Out).
 
-test(valid_object_id_is_uuid) :-
-    zanzibar_tuple:parse_tuple("ns:1e5d2006-89e1-4264-a71a-fd45f3926131#rel@user-id", Out),
-    Out = t(o("ns", "1e5d2006-89e1-4264-a71a-fd45f3926131"), r("rel"), u(id("user-id"))).
+test(valid_numeric_userid, [ true(
+    Out=t(
+        o("ns", "object"), 
+        r("rel"), 
+        u(id(42))
+    ))]) :- zanzibar_tuple:parse_tuple("ns:object#rel@42", Out).
 
-test(valid_user_id_and_object_id_are_uuid) :-
-    zanzibar_tuple:parse_tuple("ns:1e5d2006-89e1-4264-a71a-fd45f3926131#rel@f26fe405-814c-44fd-a188-56cdcefe5de5", Out),
-    Out = t(o("ns", "1e5d2006-89e1-4264-a71a-fd45f3926131"), r("rel"), u(id("f26fe405-814c-44fd-a188-56cdcefe5de5"))).
+test(invalid_objectid, [ true(
+    Out=t(
+        o("ns", "object"),
+        error(expected, relation),
+        error(expected, user_or_userset,
+            received([
+                token(symbol,'-'),
+                token(kw,"id"),
+                token(symbol,'#'),
+                token(kw,"rel"),
+                token(symbol,'@')]))
+    ))]) :- zanzibar_tuple:parse_tuple("ns:object-id#rel@", Out).
 
-test(invalid_top_level_object_no_ns) :-
-    not(zanzibar_tuple:parse_tuple("object#rel@user-id", _Out)).
+test(invalid_userid, [ true(
+    Out=t(
+        o("ns", "object"),
+        r("rel"),
+        error(expected, user_or_userset,
+            received([
+                token(symbol, '@'),
+                token(kw, "user"),
+                token(symbol, '-'),
+                token(kw, "id")]))
+    ))]) :- zanzibar_tuple:parse_tuple("ns:object#rel@user-id", Out).
 
-test(invalid_top_level_dotdotdot_relation) :-
-    not(zanzibar_tuple:parse_tuple("ns:object#...@user-id", _Out)).
+test(invalid_top_level_object_no_ns, [ true(
+    Out=t(
+        error(expected, object),
+        error(expected, relation),
+        error(expected, user_or_userset,
+            received([
+                token(kw,"object"),
+                token(symbol, '#'),
+                token(kw, "rel"),
+                token(symbol, '@'),
+                token(kw, "user"),
+                token(symbol,'-'),
+                token(kw,"id")]))
+    ))]) :- zanzibar_tuple:parse_tuple("object#rel@user-id", Out).
 
-test(invalid_top_level_relation_is_uuid) :-
-    not(zanzibar_tuple:parse_tuple("object#0e7112da-200a-419a-ad65-58cecd1bcfae@user-id", _Out)).
+test(invalid_top_level_dotdotdot_relation, [ true(
+    Out=t(
+        o("ns", "object"),
+        error(expected, relation),
+        error(expected, user_or_userset,
+            received([
+                token(symbol, '#'),
+                token(symbol, '...'),
+                token(symbol, '@'),
+                token(kw, "user"),
+                token(symbol, '-'),
+                token(kw, "id")]))
+    ))]) :- zanzibar_tuple:parse_tuple("ns:object#...@user-id", Out).
 
-test(invalid_userset_object_no_ns) :-
-    not(zanzibar_tuple:parse_tuple("ns:object#rel@object#rel", _Out)).
+test(invalid_userset_object_no_ns, [ true(
+    Out=t(
+        o("ns", "object"),
+        r("rel"),
+        error(expected, user_or_userset,
+            received([
+                token(symbol, '@'),
+                token(kw, "object"),
+                token(symbol, '#'),
+                token(kw, "rel")]))
+    ))]) :- zanzibar_tuple:parse_tuple("ns:object#rel@object#rel", Out).
 
 :- end_tests(zanzibar_tuple_tests).


### PR DESCRIPTION
Reading data from _difference lists_ while expecting a specific form is difficult because DCGs make it really difficult to thread errors while backtracking.

It's better to tokenize and parse the resulting tokens. Here, tuple parser as an example.

The tokenizer will be useful for namespace configuration handling.

Improves tests.