### PR TITLE
Add a general syntax parser for the namespace configuration

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -17,6 +17,9 @@ jobs:
           ls -la $GITHUB_WORKSPACE
           echo $(pwd)
           ls -la $(pwd)
+      - name: Run config namespace parser tests
+        run: |
+          docker run -v $GITHUB_WORKSPACE:/source -w /source swipl:8.5.17 swipl -g run_tests -t halt zanzibar_config_ns_parser_test.pl
       - name: Run tokenizer tests
         run: |
           docker run -v $GITHUB_WORKSPACE:/source -w /source swipl:8.5.17 swipl -g run_tests -t halt zanzibar_tokenizer_test.pl

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: test
-test: test-tokenizer test-tuple test-utils
+test: test-config-ns-parser test-tokenizer test-tuple test-utils
+
+.PHONY: test-config-ns-parser
+test-config-ns-parser:
+	swipl -g run_tests -t halt zanzibar_config_ns_parser_test.pl
 
 .PHONY: test-tokenizer
 test-tokenizer:

--- a/zanzibar_config_ns_parser.pl
+++ b/zanzibar_config_ns_parser.pl
@@ -1,0 +1,82 @@
+:- module(zanzibar_config_ns_parser,
+    [parse_config/2]).
+
+% Enable double-quoted strings for ease of use.
+:- set_prolog_flag(double_quotes, chars).
+:- use_module(library(dcg/basics)).
+:- use_module(zanzibar_tokenizer).
+:- use_module(zanzibar_utils).
+
+config(tokens(Ts), Out) :- block_body(Ts, _, Out, []).
+
+block_body([], [], Acc, Acc) :- !.
+
+block_body([H|T], Rest, Out, Acc) :-
+    scope_end([H|T], Rest, Out, Acc),
+    !.
+
+block_body([H|T], Rest, Out, Acc) :-
+    kv([H|T], T2, Item),
+    !, block_body(T2, Rest, Out, [Item|Acc]).
+
+block_body([H|T], Rest, Out, Acc) :-
+    block([H|T], T2, Item),
+    !, block_body(T2, Rest, Out, [Item|Acc]).
+
+block([], [], Acc, Acc).
+block([token(kw, Kw), token(scope_s, '{') | T], Rest, block(Kw, Out)) :-
+    block_body(T, Rest, Out, []), !.
+
+% -------------------------------------------|
+% Key/value handling:
+% -------------------------------------------|
+kv([token(kw, K), token(assign,'='), token(qs, V) | T], T, kv(K, V)).
+kv([token(kw, K), token(assign,'='), token(float, V) | T], T, kv(K, V)).
+kv([token(kw, K), token(assign,'='), token(number, V) | T], T, kv(K, V)).
+kv([token(kw, K), token(assign,'='), token(kw, true) | T], T, kv(K, true)).
+kv([token(kw, K), token(assign,'='), token(kw, false) | T], T, kv(K, false)).
+kv([token(kw, K), token(assign,'='), token(symbol, '$'), token(kw, V) | T], T, kv(K, var(V))).
+
+% -------------------------------------------|
+% General:
+% -------------------------------------------|
+
+scope_end([H|T], T2, Acc, Acc) :-
+    [token(scope_e, '}') | T2] = [H|T].
+
+% -------------------------------------------|
+% API:
+% -------------------------------------------|
+parse_config(In, ast(Out)) :-
+    zanzibar_tokenizer:tokenize(In, Tokens),
+    config(Tokens, Out).
+
+example(Out) :-
+    parse_config("
+    name = \"name1\"
+
+    property1 = 1.0
+    property2 = 42
+    property3 = false
+    property4 = $variable
+
+    relation {
+        nested_block1 {
+            name = \"nested name\"
+            child {
+                name = \"child\"
+            }
+        }
+        nested_block2 {
+        }
+        nested_block3 {
+            nested_block3_1 {
+            }
+            nested_block3_2 {
+                child {
+                    name = \"child 3.2\"
+                }
+            }
+        }
+    }
+    ", Out).

--- a/zanzibar_config_ns_parser_test.pl
+++ b/zanzibar_config_ns_parser_test.pl
@@ -1,0 +1,61 @@
+:- begin_tests(zanzibar_config_ns_parser_tests).
+
+% Enable double-quoted strings for ease of use.
+:- set_prolog_flag(double_quotes, chars).
+:- use_module(zanzibar_config_ns_parser).
+
+test(valid_nested_blocks, [ true( Out =
+    ast([
+        block(relation, [
+            block(nested_block3, [
+                block(nested_block3_2, [
+                    block(child, [
+                        kv(name, "child 3.2")
+                    ])
+                ]),
+                block(nested_block3_1, [])
+            ]),
+            block(nested_block2, []),
+            block(nested_block1, [
+                block(child, [
+                    kv(name, "child")
+                ]),
+                kv(name, "nested name")
+            ])
+        ]),
+        kv(property4, var(variable)),
+        kv(property3, false),
+        kv(property2, 42),
+        kv(property1, 1.0),
+        kv(name, "name1")
+    ])
+    )]) :- parse_config("
+    name = \"name1\"
+
+    property1 = 1.0
+    property2 = 42
+    property3 = false
+    property4 = $variable
+
+    relation {
+        nested_block1 {
+            name = \"nested name\"
+            child {
+                name = \"child\"
+            }
+        }
+        nested_block2 {
+        }
+        nested_block3 {
+            nested_block3_1 {
+            }
+            nested_block3_2 {
+                child {
+                    name = \"child 3.2\"
+                }
+            }
+        }
+    }
+    ", Out).
+
+:- end_tests(zanzibar_config_ns_parser_tests).


### PR DESCRIPTION
Instead of mixing parsing and lexing, parse the configuration into a general:

```
block      := block_body
block_body := kv | block | ...
config     := block_body
kv         := keyword = [ quoted_string | number | float | keyword | '$' keyword ]
```
